### PR TITLE
UUID type added to coerceColType function

### DIFF
--- a/dbml_sqlite/core.py
+++ b/dbml_sqlite/core.py
@@ -261,14 +261,11 @@ def coerceColType(colType):
     texts = ('STR', 'DATE', 'DATETIME', 'TIMESTAMP', 'TIME', 'VARCHAR', 'TINYTEXT', 'SMALLTEXT', 'MEDIUMTEXT', 'LONGTEXT')
     if colType in texts:
         return 'TEXT'
-    blobs = ('TINYBLOB', 'SMALLBLOB', 'MEDIUMBLOB', 'LONGBLOB', 'BYTE', 'BYTES')
+    blobs = ('TINYBLOB', 'SMALLBLOB', 'MEDIUMBLOB', 'LONGBLOB', 'BYTE', 'BYTES', 'UUID')
     if colType in blobs:
         return 'BLOB'
     res = re.search(r'VARCHAR\([0-9]+\)', colType)
     if res:
         return 'TEXT'
-    same_types = ('UUID')
-    if colType in same_types:
-        return colType
     else:
         raise ValueError(f'Could not figure out how to coerce "{colType}" to valid SQLite type.')

--- a/dbml_sqlite/core.py
+++ b/dbml_sqlite/core.py
@@ -267,5 +267,8 @@ def coerceColType(colType):
     res = re.search(r'VARCHAR\([0-9]+\)', colType)
     if res:
         return 'TEXT'
+    same_types = ('UUID')
+    if colType in same_types:
+        return colType
     else:
         raise ValueError(f'Could not figure out how to coerce "{colType}" to valid SQLite type.')


### PR DESCRIPTION
Added a new possibility to the coerceColType function: same_types. For now, I only added 'UUID' as an option, but it can be expanded in the future for other cases that fit in it as well.